### PR TITLE
Add tensorflow as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
                       'pyarrow',
                       'more_itertools',
                       'textacy',
-                      'keras'],
+                      'keras',
+                      'tensorflow'],
     extras_require={
         'h5py': ['h5py'],
         'visualize': ['pydot'],


### PR DESCRIPTION
`tensorflow` must be installed to import `ktext`, and should be added as an explicit dependency in `setup.py`